### PR TITLE
Comment out old Velocity hook code

### DIFF
--- a/js/bin/materialize.js
+++ b/js/bin/materialize.js
@@ -792,7 +792,7 @@ if ($) {
         });
       }
       else {
-        $.Velocity.hook($modal, "scaleX", 0.7);
+        //$.Velocity.hook($modal, "scaleX", 0.7);
         $modal.css({ top: options.starting_top });
         $modal.velocity({top: "10%", opacity: 1, scaleX: '1'}, {
           duration: options.in_duration,


### PR DESCRIPTION
We're using the latest Velocity which no longer supports the .hook method. I've commented that part out in materialize.js.